### PR TITLE
Fix Cloudflare deploy as static site; remove Vercel analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# cloudflare / wrangler
+.wrangler/
+.dev.vars
+wrangler-configuration.d.ts
+worker-configuration.d.ts
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,16 +1,7 @@
-# Ignore everything
-/*
-
-# Except these files & folders
-!/src
-!/public
-!/.github
-!tsconfig.json
-!astro.config.ts
-!.prettierrc.mjs
-!package.json
-!.prettierrc
-!eslint.config.js
-!README.md
-
+.astro
+.claude
+.wrangler
+dist
+node_modules
 bun.lock
+

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -10,7 +10,7 @@
     "endOfLine": "lf",
     "plugins": ["prettier-plugin-astro", "prettier-plugin-organize-imports", "prettier-plugin-tailwindcss"],
     "tailwindStylesheet": "./src/styles/global.css",
-   "overrides": [
+    "overrides": [
         {
             "files": "*.astro",
             "options": {

--- a/astro.config.js
+++ b/astro.config.js
@@ -1,16 +1,13 @@
-// @ts-check
 import { defineConfig } from "astro/config";
-import tailwindcss from "@tailwindcss/vite";
-
-import react from "@astrojs/react";
 
 import mdx from "@astrojs/mdx";
-
+import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
+import tailwindcss from "@tailwindcss/vite";
 
-// https://astro.build/config
 export default defineConfig({
-  site: 'https://developershihab.com',
-  integrations: [react(), mdx(), sitemap()],
-  vite: {plugins: [tailwindcss()]},
+    site: "https://developershihab.com",
+    output: "static",
+    integrations: [react(), mdx(), sitemap()],
+    vite: { plugins: [tailwindcss()] },
 });

--- a/bun.lock
+++ b/bun.lock
@@ -17,8 +17,6 @@
         "@types/react": "^19.0.12",
         "@types/react-dom": "^19.0.4",
         "@typescript-eslint/parser": "^8.28.0",
-        "@vercel/analytics": "^1.5.0",
-        "@vercel/speed-insights": "^1.2.0",
         "astro": "^5.5.4",
         "astro-og-canvas": "^0.11.1",
         "class-variance-authority": "^0.7.1",
@@ -56,7 +54,6 @@
   },
   "trustedDependencies": [
     "@tailwindcss/oxide",
-    "@vercel/speed-insights",
     "sharp",
     "esbuild",
     "puppeteer",
@@ -453,10 +450,6 @@
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.41.0", "", { "dependencies": { "@typescript-eslint/types": "8.41.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
-
-    "@vercel/analytics": ["@vercel/analytics@1.5.0", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g=="],
-
-    "@vercel/speed-insights": ["@vercel/speed-insights@1.2.0", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
         "@types/react": "^19.0.12",
         "@types/react-dom": "^19.0.4",
         "@typescript-eslint/parser": "^8.28.0",
-        "@vercel/analytics": "^1.5.0",
-        "@vercel/speed-insights": "^1.2.0",
         "astro": "^5.5.4",
         "astro-og-canvas": "^0.11.1",
         "class-variance-authority": "^0.7.1",
@@ -60,7 +58,6 @@
     },
     "trustedDependencies": [
         "@tailwindcss/oxide",
-        "@vercel/speed-insights",
         "esbuild",
         "puppeteer",
         "sharp"

--- a/src/components/layouts/site/layout.astro
+++ b/src/components/layouts/site/layout.astro
@@ -3,8 +3,6 @@ import { name, role, website, desc, pageType as xPageType } from "@/lib/informat
 
 import "@/styles/global.css";
 
-import Analytics from "@vercel/analytics/astro";
-import SpeedInsights from "@vercel/speed-insights/astro";
 import BackToTop from "@/components/ui/back-to-top.astro";
 
 export interface Props {
@@ -106,8 +104,6 @@ const structuredData = {
     <body class="relative min-h-screen overflow-x-hidden">
         <slot />
         <BackToTop />
-        <Analytics />
-        <SpeedInsights />
     </body>
 </html>
 

--- a/src/pages/articles/categories/[category].astro
+++ b/src/pages/articles/categories/[category].astro
@@ -27,7 +27,12 @@ const title = category;
 const description = `Exploring ${category} insights, lessons, and discoveries from my programming journey.`;
 ---
 
-<PageLayout backLink="/articles" description={description} title={title} ogImage={`/og/articles/categories/${category}.png`}>
+<PageLayout
+    backLink="/articles"
+    description={description}
+    title={title}
+    ogImage={`/og/articles/categories/${category}.png`}
+>
     <Pattern />
 
     <Box>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -15,7 +15,11 @@ import BoxTitle from "@/components/ui/box-title.astro";
 import PageLayout from "@/components/layouts/page/layout.astro";
 ---
 
-<PageLayout title="Contact" description="Get in touch with me via email or connect on social media." ogImage="/og/contact.png">
+<PageLayout
+    title="Contact"
+    description="Get in touch with me via email or connect on social media."
+    ogImage="/og/contact.png"
+>
     <Box>
         <BoxHeader>
             <BoxTitle>Reach out</BoxTitle>

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "node_modules/wrangler/config-schema.json",
+    "name": "developershihab-com",
+    "compatibility_date": "2025-07-25",
+    "assets": {
+        "directory": "./dist"
+    }
+}


### PR DESCRIPTION
- Add wrangler.json so wrangler deploys dist as static assets and skips
  the auto-config that injected the SSR adapter (caused __dirname crash
  in canvaskit OG image generation)
- Set explicit output: static in astro.config
- Remove @vercel/analytics and @vercel/speed-insights (deps + layout)
- Ignore .wrangler/, .dev.vars, and generated worker types
